### PR TITLE
Simplifications and enhancements

### DIFF
--- a/ListDisks
+++ b/ListDisks
@@ -1,17 +1,24 @@
 #!/bin/bash
-fdisk -l | grep Disk | sort | grep --color=auto '\/sd\|\/nvm' | while read line ; do
-  Device=`echo $line | cut -d ' ' -f 2 | cut -d ':' -f 1`
-  udevadm info --query=all -n $Device > /dev/shm/tmp.ListDisks
+sudo fdisk -l | grep Disk | sort | grep '\/sd\|\/nvm' | while read line; do
+  Device=$(echo $line | cut -d ' ' -f 2 | cut -d ':' -f 1)
+  driveInfo=$(udevadm info --query=all -n $Device)
   if [[ $Device == *nvme* ]]; then
     Mode="NVMe"
   else
-    ID_PATH=`cat /dev/shm/tmp.ListDisks | grep 'ID_PATH='`
-    echo $ID_PATH | grep -i USB &> /dev/null && Mode="USB"
-    echo $ID_PATH | grep -i ATA &> /dev/null && Mode="ATA"
-    echo $ID_PATH | grep -i SAS &> /dev/null && Mode="SAS"
+    ID_PATH=$(echo "$driveInfo" | grep 'ID_PATH=')
+    echo $ID_PATH | grep -i USB &>/dev/null && Mode="USB"
+    echo $ID_PATH | grep -i ATA &>/dev/null && Mode="ATA"
+    echo $ID_PATH | grep -i SAS &>/dev/null && Mode="SAS"
   fi
-  ID_MODEL=`cat /dev/shm/tmp.ListDisks | grep 'ID_MODEL=' | sed 's\[\]x20\ \g' | cut -d '=' -f 2`
-  ID_SERIAL_SHORT=`cat /dev/shm/tmp.ListDisks | grep 'ID_SERIAL_SHORT=' | cut -d '=' -f 2`
-  Size=`echo $line | cut -d ' ' -f 3-4`
-  echo "Device: $Device, Size: $Size Model: $ID_MODEL, Serial: $ID_SERIAL_SHORT, Mode: $Mode" | tr -s ' ' | sed 's\ ,\,\g'
+
+  deviceName=$(echo $Device | cut -c 6-)
+  Rotational=$(cat /sys/block/$deviceName/queue/rotational)
+  [[ "$Rotational" == "0" && "$deviceName" == *nvme* ]] && Type='NVMe'
+  [[ "$Rotational" == "0" ]] && Type='SSD'
+  [[ "$Rotational" == "1" ]] && Type='HDD'
+
+  ID_MODEL=$(echo "$driveInfo" | grep 'ID_MODEL=' | sed 's\[\]x20\ \g' | cut -d '=' -f 2)
+  ID_SERIAL_SHORT=$(echo "$driveInfo" | grep 'ID_SERIAL_SHORT=' | cut -d '=' -f 2)
+  Size=$(echo $line | cut -d ' ' -f 3-4)
+  echo "Device: $Device, Size: $Size Model: $ID_MODEL, Serial: $ID_SERIAL_SHORT, Mode: $Mode, Type: $Type" | tr -s ' ' | sed 's\ ,\,\g'
 done

--- a/ListDisks
+++ b/ListDisks
@@ -6,9 +6,9 @@ sudo fdisk -l | grep Disk | sort | grep '\/sd\|\/nvm' | while read line; do
     Mode="NVMe"
   else
     ID_PATH=$(echo "$driveInfo" | grep 'ID_PATH=')
-    echo $ID_PATH | grep -i USB &>/dev/null && Mode="USB"
-    echo $ID_PATH | grep -i ATA &>/dev/null && Mode="ATA"
-    echo $ID_PATH | grep -i SAS &>/dev/null && Mode="SAS"
+    echo $ID_PATH | grep -q -i USB && Mode="USB"
+    echo $ID_PATH | grep -q -i ATA && Mode="ATA"
+    echo $ID_PATH | grep -q -i SAS && Mode="SAS"
   fi
 
   deviceName=$(echo $Device | cut -c 6-)

--- a/ListDisks
+++ b/ListDisks
@@ -14,7 +14,7 @@ sudo fdisk -l | grep Disk | sort | grep '\/sd\|\/nvm' | while read line; do
   deviceName=$(echo $Device | cut -c 6-)
   Rotational=$(cat /sys/block/$deviceName/queue/rotational)
   [[ "$Rotational" == "0" && "$deviceName" == *nvme* ]] && Type='NVMe'
-  [[ "$Rotational" == "0" ]] && Type='SSD'
+  [[ "$Rotational" == "0" && "$deviceName" == *sd* ]] && Type='SSD'
   [[ "$Rotational" == "1" ]] && Type='HDD'
 
   ID_MODEL=$(echo "$driveInfo" | grep 'ID_MODEL=' | sed 's\[\]x20\ \g' | cut -d '=' -f 2)


### PR DESCRIPTION
- Added sudo requirement for fdisk.
- Added detection of rotational disks, useful info to differentiate hdd from ssd and nvme.
- Removed the `--color-auto` from grep, it doesn't matter here since it doesn't show up in the final results.
- Stored the `udevadm` information into a variable, instead of a tmp file in /dev/shm (which wasn't deleted by the way, after the script is finished).

Note that I'm using double quotes when calling `echo "$driveInfo"` otherwise the strings are concatenated into one line, which messes up the following grep command.